### PR TITLE
优化自动化 gulp 性能

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,24 +4,38 @@ const cleanCSS = require('gulp-clean-css')
 const concat = require('gulp-concat')
 const rename = require('gulp-rename')
 
-gulp.task('minify-css', () => {
-  return gulp.src('src/css/*.css')
-    .pipe(cleanCSS({compatibility: 'ie8'}))
-    .pipe(rename('artitalk.min.css'))
-    .pipe(gulp.dest('dist/css'));
-});
+const minify_css = () => (
+    gulp.src('src/css/*.css')
+        .pipe(cleanCSS({ compatibility: 'ie8' }))
+        .pipe(rename('artitalk.min.css'))
+        .pipe(gulp.dest('dist/css'))
+);
 
-gulp.task('concat-js', () => {
-  return gulp.src(['src/plugins/*.js', 'src/main.js'])
-    .pipe(concat('artitalk.js'))
-    .pipe(gulp.dest('dist/js'))
-});
+const concat_js = () => (
+    gulp.src(['src/plugins/*.js', 'src/main.js'])
+        .pipe(concat('artitalk.js'))
+        .pipe(gulp.dest('dist/js'))
+);
 
-gulp.task('minify-js', () => {
-  return gulp.src('dist/js/artitalk.js')
-    .pipe(uglify())
-    .pipe(rename('artitalk.min.js'))
-    .pipe(gulp.dest('dist/js'))
-});
+const minify_js = () => (
+    gulp.src('dist/js/artitalk.js')
+        .pipe(uglify())
+        .pipe(rename('artitalk.min.js'))
+        .pipe(gulp.dest('dist/js'))
+);
 
-gulp.task('default', gulp.series('minify-css', 'concat-js', 'minify-js'));
+module.exports = {
+    minify_css: minify_css,
+    concat_js: concat_js,
+    minify_js: minify_js
+};
+
+gulp.task('dist', gulp.parallel(
+    minify_css,
+    gulp.series(
+        concat_js,
+        minify_js
+    )
+))
+
+gulp.task('default', gulp.series('dist'));


### PR DESCRIPTION
Gulp 早在 2015 年便发布了 `4.0` 版本，且不提 `3.x` 版本的高危漏洞，众多诸如 `gulp.series` 和 `gulp.parallel` 的新特性也是 `4.0` 中带来的。

ArtitalkJS 虽说已经用上 `gulp@4.0.2`，但是似乎并非是完全按照第四个大版本来编写 `gulpfile.js` 的。此言理由有二：

1. gulp 4.0 在更新日志里描述道：除非这个任务需要使用 gulp taskname 调用，否则不再建议使用 `gulp.task` 注册。而贵项目中所有任务都是使用 `gulp.task` 注册的。
2. 贵项目似乎没有将 gulp 4.0 新增了两个革命性 API —— `gulp.series` 和 `gulp.parallel` 物尽其用。CSS 的压缩与 JS 的合并压缩是没有依赖关系的，完全可以让 CSS 压缩 和 JS 合并压缩同步运行，减少处理时间，优化性能。

此次 PR 主要针对上面两点，统一采用 gulpjs 官方推荐的通过函数注册任务，并充分利用 `gulp.series` 和 `gulp.parallel` 将自动化编译处理时间优化超过 `40%`（本地测试）。

希望 ArtitalkJS 小组成员（@Drew233、@jalenchuh、@Flexiston、@ChenYFan，etc）能够阅读上述描述并决定是否合并。当然，如果均认为「本来也就 3 秒的自动化编译干嘛闲着没事还去优化」、「没必要揪着官方推荐实现不放代码能用就行」的，大可关闭此 PR，我不会介意。

