### PR TITLE
防止AV多次初始化

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -258,6 +258,7 @@ atEvery.prototype.init=function(option){
     !!option && root._init();
     return root;
 }
+let _initialized = false;
 atEvery.prototype._init=function(){
     let root=this;
     let {
@@ -444,27 +445,30 @@ atEvery.prototype._init=function(){
     color3 = typeof(color3)==="undefined" || color3 === '' ? "white":color3;
     pageSize = typeof(pageSize)==="undefined" ? '5':pageSize;
     let apiUrl="";
-    try{
-        if(serverURL !== ''){
-            AV.init({
-                appId: appId,
-                appKey: appKey,
-                serverURL: serverURL,
-            });
-        }else{
-            AV.init({
-                appId: appId,
-                appKey: appKey,
-            });
+    if (!_initialized){
+        try{
+            if(serverURL !== ''){
+                AV.init({
+                    appId: appId,
+                    appKey: appKey,
+                    serverURL: serverURL,
+                });
+            }else{
+                AV.init({
+                    appId: appId,
+                    appKey: appKey,
+                });
+            }
+            _initialized = true;
         }
-    }
-    catch(error){
-        let err=error.toString();
-        console.error(err);
-        if(err.indexOf('appId is not defined')!=-1){
-            console.log("appId没找到");
-        }else if(err.indexOf('appKey is not defined')!=-1){
-            console.log("appKey没找到");
+        catch(error){
+            let err=error.toString();
+            console.error(err);
+            if(err.indexOf('appId is not defined')!=-1){
+                console.log("appId没找到");
+            }else if(err.indexOf('appKey is not defined')!=-1){
+                console.log("appKey没找到");
+            }
         }
     }
     //emoji translate


### PR DESCRIPTION
以[我的个人博客](https://blog.allwens.work/talk/)为例，在Pjax网站中对说说页面多次访问，会出现如下提示：
![2020-12-17_14-37](https://user-images.githubusercontent.com/32017007/102452738-d42cf700-4075-11eb-8a35-b345d3c83fbc.png)
查看[源码](https://leancloud.github.io/javascript-sdk/docs/init.js.html#line44)后发现是由于多次调用`AV.init`方法，因此尝试加入标志变量，防止`AV.init`多次调用。